### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,20 @@
 # spotify-adblock-linux ![Language](https://img.shields.io/github/languages/top/vsvinav/spotify-adblock-linux?style=flat)
 
-
 Installation   
 ------------
-$`git clone https://github.com/vsvinav/spotify-adblock-linux.git`
-
-$`cd spotify-adblock-linux`
-
-$`pip3 install -r requirements.txt`
-
+```
+$ git clone https://github.com/vsvinav/spotify-adblock-linux.git
+$ cd spotify-adblock-linux
+$ pip3 install -r requirements.txt
+```
 
 Usage   
 -----
 Open Spotify before running the script
 
-$`python3 adspotter` (keep it running)
-
+`$ python adspotter.py` (keep it running)
 
 Troubleshooting
 -----
-If in case you're not able to install dbus-python, run `sudo apt-get install libdbus-1-dev libdbus-glib-1-dev` to fix. And then run $`pip3 install -r requirements.txt` again.
+If in case you're not able to install dbus-python, run `# apt-get install libdbus-1-dev libdbus-glib-1-dev` to fix.
+And then run `$ pip3 install -r requirements.txt` again.


### PR DESCRIPTION
When executing the script, ".py" could be omitted because of the shebang "#!/usr/bin/env python3" so that if the script is added as a command by exporting the path it could be run as `addspotter` instead of `adspotter.py`  but since you kept it in the file, i added it in the usage to be consistent. Eventually enhanced the installation commands markdown. I suggest you to add a description like "A Spotify adblocker for Linux" in the description section and under the README title.
Also keep in mind that if you use "python" instead of "python3", if someone have python2 set for the "python" command it won't work because the script is not python2 compliant, i didnt change this tho because it might be your preference.